### PR TITLE
Aliging contracts with new semantics

### DIFF
--- a/src/apps/models/contract.go
+++ b/src/apps/models/contract.go
@@ -150,3 +150,12 @@ func GetContracts(identityId uuid.UUID, p database.Paginate) ([]Contract, int, e
 	}
 	return contracts, fetchList[0].TotalCount, nil
 }
+
+func (c *Contract) Delete(ctx context.Context) error {
+	rows, err := database.Query(ctx, "contracts/delete", c.ID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	return nil
+}

--- a/src/apps/models/contract.go
+++ b/src/apps/models/contract.go
@@ -26,14 +26,17 @@ type Contract struct {
 	CommitmentPeriodCount int                      `db:"commitment_period_count" json:"commitment_period_count"`
 	PaymentType           *PaymentModeType         `db:"payment_type" json:"payment_type"`
 
-	ProviderID uuid.UUID `db:"provider_id" json:"provider_id"`
-	ClientID   uuid.UUID `db:"client_id" json:"client_id"`
+	ProviderID uuid.UUID `db:"provider_id" json:"-"`
+	ClientID   uuid.UUID `db:"client_id" json:"-"`
+
+	Provider *Identity `db:"-" json:"provider"`
+	Client   *Identity `db:"-" json:"client"`
 
 	ApplicantID *uuid.UUID `db:"applicant_id" json:"applicant_id"`
 	ProjectID   *uuid.UUID `db:"project_id" json:"project_id"`
 	PaymentID   *uuid.UUID `db:"payment_id" json:"payment_id"`
-	OfferID     *uuid.UUID `db:"offer_id" json:"-"`
-	MissionID   *uuid.UUID `db:"mission_id" json:"-"`
+	OfferID     *uuid.UUID `db:"offer_id" json:"offer_id"`
+	MissionID   *uuid.UUID `db:"mission_id" json:"mission_id"`
 
 	CreatedAt time.Time `db:"created_at" json:"created_at"`
 	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`

--- a/src/apps/models/enum.go
+++ b/src/apps/models/enum.go
@@ -232,6 +232,7 @@ const (
 	ContractStatusSinged           ContractStatus = "SIGNED"
 	ContractStatusProviderCanceled ContractStatus = "PROVIDER_CANCELED"
 	ContractStatusClientCanceled   ContractStatus = "CLIENT_CANCELED"
+	ContractStatusApplied          ContractStatus = "APPLIED"
 	ContractStatusCompleted        ContractStatus = "COMPLETED"
 )
 

--- a/src/apps/models/identity.go
+++ b/src/apps/models/identity.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -9,10 +11,11 @@ import (
 )
 
 type Identity struct {
-	ID        uuid.UUID      `db:"id" json:"id"`
-	Type      IdentityType   `db:"type" json:"type"`
-	Meta      types.JSONText `db:"meta" json:"meta"`
-	CreatedAt time.Time      `db:"created_at" json:"created_at"`
+	ID        uuid.UUID              `db:"id" json:"id"`
+	Type      IdentityType           `db:"type" json:"type"`
+	MetaMap   map[string]interface{} `db:"-" json:"-"`
+	Meta      types.JSONText         `db:"meta" json:"meta"`
+	CreatedAt time.Time              `db:"created_at" json:"created_at"`
 }
 
 func (Identity) TableName() string {
@@ -26,6 +29,10 @@ func (Identity) FetchQuery() string {
 func GetIdentity(id uuid.UUID) (*Identity, error) {
 	i := new(Identity)
 	if err := database.Fetch(i, id); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(i.Meta, &i.MetaMap); err != nil {
+		fmt.Println("Error unmarshaling Meta:", err)
 		return nil, err
 	}
 	return i, nil

--- a/src/apps/models/project.go
+++ b/src/apps/models/project.go
@@ -254,12 +254,16 @@ func GetProjects(identityId uuid.UUID, p database.Paginate) ([]Project, int, err
 
 	if len(p.Filters) > 0 {
 		var kind string
+		optionalIdentityId := identityId
 		for _, filter := range p.Filters {
 			if filter.Key == "kind" {
 				kind = filter.Value
 			}
+			if filter.Key == "identity_id" {
+				optionalIdentityId = uuid.MustParse(filter.Value)
+			}
 		}
-		if err := database.QuerySelect("projects/get_by_kind", &fetchList, identityId, p.Limit, p.Offet, kind); err != nil {
+		if err := database.QuerySelect("projects/get_by_kind", &fetchList, optionalIdentityId, p.Limit, p.Offet, kind); err != nil {
 			return nil, 0, err
 		}
 

--- a/src/apps/views/projects.go
+++ b/src/apps/views/projects.go
@@ -17,10 +17,10 @@ func projectsGroup(router *gin.Engine) {
 	g.Use(auth.LoginRequired())
 
 	g.GET("", paginate(), func(c *gin.Context) {
-		u, _ := c.Get("user")
+		identity, _ := c.Get("identity")
 		page, _ := c.Get("paginate")
 
-		projects, total, err := models.GetProjects(u.(*models.User).ID, page.(database.Paginate))
+		projects, total, err := models.GetProjects(identity.(*models.Identity).ID, page.(database.Paginate))
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -44,7 +44,7 @@ func projectsGroup(router *gin.Engine) {
 
 	g.POST("", func(c *gin.Context) {
 		ctx, _ := c.Get("ctx")
-		u, _ := c.Get("user")
+		identity, _ := c.Get("identity")
 
 		form := new(ProjectForm)
 		if err := c.ShouldBindJSON(form); err != nil {
@@ -54,7 +54,7 @@ func projectsGroup(router *gin.Engine) {
 
 		p := new(models.Project)
 		utils.Copy(form, p)
-		p.IdentityID = u.(*models.User).ID
+		p.IdentityID = identity.(*models.Identity).ID
 		if err := p.Create(ctx.(context.Context), form.WorkSamples); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return

--- a/src/sql/contracts/delete.sql
+++ b/src/sql/contracts/delete.sql
@@ -1,0 +1,3 @@
+DELETE
+FROM contracts
+WHERE id=$1

--- a/src/sql/contracts/fetch.sql
+++ b/src/sql/contracts/fetch.sql
@@ -11,3 +11,4 @@ LEFT JOIN projects p ON p.id = c.project_id
 LEFT JOIN applicants a ON a.id = c.applicant_id
 LEFT JOIN payments pay ON pay.id = c.payment_id
 WHERE c.id IN (?)
+ORDER BY c.created_at DESC

--- a/src/sql/migrations/20250110014250_bridge-add-payment.up.sql
+++ b/src/sql/migrations/20250110014250_bridge-add-payment.up.sql
@@ -1,0 +1,267 @@
+-- Delete previous Contracts
+DELETE FROM contracts;
+
+-- Add Triggers
+CREATE OR REPLACE FUNCTION upsert_contract_on_offer() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    contract RECORD;
+    project RECORD;
+    payment RECORD;
+    contract_name TEXT;
+    contract_status TEXT;
+    v_commitment_period TEXT;
+    v_commitment_period_count INTEGER;
+    v_payment_id uuid;
+BEGIN
+    SELECT * INTO contract
+    FROM contracts
+    WHERE offer_id = NEW.id;
+
+    SELECT * INTO project
+    FROM projects
+    WHERE id = NEW.project_id AND payment_type IS NOT NULL;
+
+    SELECT * INTO payment
+    FROM payments
+    WHERE meta->>'offer_id' = NEW.id::text
+    ORDER BY created_at DESC
+    LIMIT 1;
+
+    contract_status := CASE
+        WHEN NEW.status='PENDING' THEN 'CREATED'
+        WHEN NEW.status='APPROVED' THEN 'SIGNED'
+        WHEN NEW.status='HIRED' THEN 'SIGNED'
+        WHEN NEW.status='WITHDRAWN' THEN 'CLIENT_CANCELED'
+        WHEN NEW.status='CANCELED' THEN 'PROVIDER_CANCELED'
+        ELSE NULL
+    END;
+
+    v_commitment_period := CASE
+        WHEN NEW.total_hours IS NOT NULL THEN 'HOURLY'
+        WHEN NEW.weekly_limit IS NOT NULL THEN 'WEEKLY'
+        ELSE NULL
+    END; --Fix: Fix calculation
+
+    v_commitment_period_count := CASE
+        WHEN NEW.total_hours IS NOT NULL THEN NEW.total_hours
+        WHEN NEW.weekly_limit IS NOT NULL THEN NEW.weekly_limit
+        ELSE NULL
+    END; --Fix: Fix calculation
+
+    IF project.id IS NULL OR contract_status IS NULL THEN
+        RETURN NEW; -- Exit the function
+    END IF;
+
+    contract_name := CASE
+        WHEN char_length(NEW.offer_message) > 128 THEN substring(NEW.offer_message FROM 1 FOR 125) || '...'
+        ELSE NEW.offer_message
+    END;
+
+    v_payment_id := CASE
+        WHEN payment IS NULL THEN NULL
+        ELSE payment.id
+    END;
+
+	
+    IF contract.id IS NOT NULL THEN
+        UPDATE contracts
+        SET
+            offer_id=NEW.id,
+            name=contract_name,
+            description=NEW.offer_message,
+            status=COALESCE(contract_status::contract_status, status),
+            type=project.payment_type::payment_type::text::contract_type,
+            currency=NEW.currency,
+            crypto_currency=NEW.crypto_currency_address,
+            total_amount=COALESCE(NEW.assignment_total, 0),
+            payment_type=NEW.payment_mode,
+            project_id=NEW.project_id,
+            payment_id=v_payment_id,
+            client_id=NEW.recipient_id,
+            provider_id=NEW.offerer_id,
+            applicant_id=NEW.applicant_id,
+            currency_rate=COALESCE(NEW.offer_rate, 1),
+            commitment=COALESCE(v_commitment_period_count, 1),--FIX
+            commitment_period=COALESCE(v_commitment_period::text::contract_commitment_period, 'HOURLY'),
+            commitment_period_count=COALESCE(v_commitment_period_count, 1)
+        WHERE id = contract.id;
+    ELSE
+        INSERT INTO
+        contracts
+        (
+            offer_id,
+            name,
+            description,
+            status,
+            type,
+            currency,
+            crypto_currency,
+            total_amount,
+            payment_type,
+            project_id,
+            payment_id,
+            client_id,
+            provider_id,
+            applicant_id,
+            currency_rate,
+            commitment,
+            commitment_period,
+            commitment_period_count
+        )
+        VALUES (
+            NEW.id,
+            contract_name,
+            NEW.offer_message,
+            contract_status::contract_status,
+            project.payment_type::payment_type::text::contract_type,
+            NEW.currency,
+            NEW.crypto_currency_address,
+            COALESCE(NEW.assignment_total, 0),
+            NEW.payment_mode,
+            NEW.project_id,
+            v_payment_id,
+            NEW.recipient_id,
+            NEW.offerer_id,
+            NEW.applicant_id,
+            COALESCE(NEW.offer_rate, 1),
+            COALESCE(v_commitment_period_count, 1), --FIX
+            COALESCE(v_commitment_period::text::contract_commitment_period, 'HOURLY'),
+            COALESCE(v_commitment_period_count, 1)
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION upsert_contract_on_mission() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    contract RECORD;
+    offer RECORD;
+    project RECORD;
+    payment RECORD;
+    contract_name TEXT;
+    contract_status TEXT;
+    v_commitment_period TEXT;
+    v_commitment_period_count INTEGER;
+    v_payment_id uuid;
+BEGIN
+    SELECT * INTO contract
+    FROM contracts
+    WHERE offer_id = NEW.offer_id;
+
+    SELECT * INTO project
+    FROM projects
+    WHERE id = NEW.project_id AND payment_type IS NOT NULL;
+
+    SELECT * INTO offer
+    FROM offers
+    WHERE id = NEW.offer_id;
+
+    SELECT * INTO payment
+    FROM payments
+    WHERE meta->>'offer_id' = NEW.offer_id::text
+    ORDER BY created_at DESC
+    LIMIT 1;
+
+    contract_status := CASE
+        WHEN NEW.status='ACTIVE' THEN 'SIGNED'
+        WHEN NEW.status='COMPLETE' THEN 'APPLIED'
+        WHEN NEW.status='CONFIRMED' THEN 'COMPLETED'
+        WHEN NEW.status='CANCELED' THEN 'CLIENT_CANCELED'
+        WHEN NEW.status='KICKED_OUT' THEN 'PROVIDER_CANCELED'
+        ELSE NULL
+    END;
+    
+    IF project.id IS NULL OR contract_status IS NULL OR offer.id IS NULL THEN
+        RETURN NEW; -- Exit the function
+    END IF;
+
+    v_commitment_period := CASE
+        WHEN offer.total_hours IS NOT NULL THEN 'HOURLY'
+        WHEN offer.weekly_limit IS NOT NULL THEN 'WEEKLY'
+        ELSE NULL
+    END;
+
+    v_commitment_period_count := CASE
+        WHEN offer.total_hours IS NOT NULL THEN offer.total_hours
+        WHEN offer.weekly_limit IS NOT NULL THEN offer.weekly_limit
+        ELSE NULL
+    END;
+
+    contract_name := CASE
+        WHEN char_length(offer.offer_message) > 128 THEN substring(offer.offer_message FROM 1 FOR 125) || '...'
+        ELSE offer.offer_message
+    END;
+
+    v_payment_id := CASE
+        WHEN payment IS NULL THEN NULL
+        ELSE payment.id
+    END;
+
+    IF contract.id IS NOT NULL THEN
+        UPDATE contracts
+        SET
+            mission_id=NEW.id,
+            status=contract_status::contract_status
+        WHERE id = contract.id;
+    ELSE
+        INSERT INTO
+        contracts
+        (
+            mission_id,
+            offer_id,
+            name,
+            description,
+            status,
+            type,
+            currency,
+            crypto_currency,
+            currency_rate,
+            total_amount,
+            payment_type,
+            project_id,
+            payment_id,
+            client_id,
+            provider_id,
+            applicant_id,
+            commitment,
+            commitment_period,
+            commitment_period_count
+        )
+        VALUES (
+            NEW.id,
+            NEW.offer_id,
+            contract_name,
+            offer.offer_message,
+            contract_status::contract_status,
+            project.payment_type::payment_type::text::contract_type,
+            offer.currency,
+            offer.crypto_currency_address,
+            COALESCE(offer.offer_rate, 1),
+            COALESCE(offer.assignment_total, 0),
+            offer.payment_mode,
+            NEW.project_id,
+            v_payment_id,
+            NEW.assignee_id,
+            NEW.assigner_id,
+            NEW.applicant_id,
+            COALESCE(v_commitment_period_count, 1), --FIX
+            COALESCE(v_commitment_period::text::contract_commitment_period, 'HOURLY'),
+            COALESCE(v_commitment_period_count, 1)
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER upsert_contract_on_offer AFTER INSERT OR UPDATE ON offers FOR EACH ROW EXECUTE FUNCTION upsert_contract_on_offer();
+CREATE OR REPLACE TRIGGER upsert_contract_on_mission AFTER INSERT OR UPDATE ON missions FOR EACH ROW EXECUTE FUNCTION upsert_contract_on_mission();
+
+-- Migrating the Offers and Missions
+UPDATE offers SET id=id;
+UPDATE missions SET id=id;

--- a/src/sql/projects/fetch.sql
+++ b/src/sql/projects/fetch.sql
@@ -22,3 +22,4 @@ FROM projects p
 JOIN identities i ON i.id=p.identity_id
 LEFT JOIN job_categories jc ON jc.id=p.job_category_id
 WHERE p.id IN (?)
+ORDER BY p.created_at DESC


### PR DESCRIPTION
feat: add missing contract status
feat: add operate endpoint to contract for doing an operation on each side
feat: add delete endpoint to contract
fix: use identity on contracts and projects endpoint instead of user
feat: add identity_id to services filters
feat: add sorting to contract and project(services)
fix: change client to provider for getting the details of the payer
fix: using identity instead of user in deposit for providing a more general solution (org/user variation)
fix: fix contract bridge and add payment_id to them and fixed statuses